### PR TITLE
Delisting 2miners CLO Pool in Hive as 2miners is not supported anymore by CLO Team

### DIFF
--- a/pool_templates/2miners.json
+++ b/pool_templates/2miners.json
@@ -110,49 +110,6 @@
         }
     },
     {
-        "coin": "CLO",
-        "servers": [
-            {
-                "geo": "EU",
-                "urls": [
-                    "clo.2miners.com:3030"
-                ]
-            },
-            {
-                "geo": "SOLO EU",
-                "urls": [
-                    "solo-clo.2miners.com:3131"
-                ]
-            },
-            {
-                "geo": "ASIA",
-                "urls": [
-                    "asia-clo.2miners.com:3030"
-                ]
-            },
-            {
-                "geo": "SOLO ASIA",
-                "urls": [
-                    "asia-solo-clo.2miners.com:3131"
-                ]
-            }
-        ],
-        "miners": {
-            "claymore": {
-                "epools_tpl": "POOL: %URL%, WALLET: %WAL%, WORKER: %WORKER_NAME%, PSW: x",
-                "claymore_user_config": "-allcoins etc\n-allpools 0"
-            },
-            "ethminer": {
-                "cuda": 1,
-                "opencl": 0,
-                "pass": "x",
-                "port": "%URL_PORT%",
-                "server": "stratum1+tcp://%URL_HOST%",
-                "template": "%WAL%.%WORKER_NAME%"
-            }
-        }
-    },
-    {
         "coin": "EXP",
         "servers": [
             {


### PR DESCRIPTION
Dear community!

After the recent events and after seeing the way "2Miners" pool handled the situation, we on Callisto noted a lack of cooperation and professionalism from their side.

Therefor 2miners pool is not supported by Callisto Team anymore.

We have taken the decision to stop any kind of relations with them and not giving support to miners mining on 2Miners pool. We are not going to help or answer any questions about that pool. In case of losses due to attacks or instability, miners who are mining on 2Miners will not be compensated. Callisto Team is not responsible for any kind of problems miners may experience, caused by mining on this pool.

Any problem that miners might have with payments, orphan blocks or losses on "2miners" pool will not receive any kind of support from Callisto Network.

There are plenty of other mining pools that support CLO and have an excellent site, interface and support team. We strongly recommend that you move your hashing powers there. A list of all supported CLO mining pools can be found on our website here:

https://callisto.network/#mining

We will be supporting these pools as we have always done. We will take care of any problems that miners could get mining on the network. We will refund in case of losses for problems on the chain.

Callisto Network.